### PR TITLE
Change domain in config to glossary.dev

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "http://example.org/"
+baseURL = "https://www.glossary.dev"
 languageCode = "en-us"
 title = "Developer Glossary"
 copyright = "MIT License, <a href='https://github.com/do-community/developer-glossary'>Contribute on GitHub</a>"


### PR DESCRIPTION
Permalinks were broken, change config to `baseURL = "https://www.glossary.dev"`