### PR TITLE
Abbreviations will now be displayed

### DIFF
--- a/layouts/terms/single.html
+++ b/layouts/terms/single.html
@@ -17,8 +17,15 @@
 
       {{ if isset .Params "synonyms" }}
         <h2>Synonyms</h2>
-        <ul>
+        <ul style="list-style: none;">
         <li>{{ delimit .Params.synonyms ", " ", and " }}</li>
+        </ul>
+      {{ end }}
+
+      {{ if isset .Params "abbreviation" }}
+        <h2>Abbreviation</h2>
+        <ul style="list-style: none;">
+        <li>{{ .Params.abbreviation }}</li>
         </ul>
       {{ end }}
 


### PR DESCRIPTION
Fixes #10 
Displays abbreviations in the front matter. Added inline CSS to not display bullet points. The only reason unordered lists were used to stay consistent with Hugo's .Content indenting its content.