### PR TITLE
Fix Single Term Page #20 #2

### DIFF
--- a/layouts/terms/single.html
+++ b/layouts/terms/single.html
@@ -1,16 +1,54 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-    <title>{{ .Site.Title }}</title>
-    <link rel="canonical" href="{{ .Permalink }}" />
-  </head>
-  <body>
 
-    {{ partial "header.html" . }}
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
+    integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z" crossorigin="anonymous">
+  <link rel="stylesheet" href="/main.css" type="text/css">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"
+    integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN"
+    crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"
+    integrity="sha384-B4gt1jrGC7Jh4AgTPSdUtOBvfO8shuf57BaghqFfPlYxofvL8/KUEfYiJOMMV+rV"
+    crossorigin="anonymous"></script>
+  <script src="/toggle.js"></script>
 
-    <main>
-        
+  <!-- Primary Meta Tags -->
+  <title>{{ .Site.Title }}</title>
+  <meta name="title" content="{{ .Site.Title }}">
+  <meta name="description"
+    content='{{if .Content}}{{ .Summary | truncate 150 }}{{else}}{{ .Site.Params.description }}{{end}}'>
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="{{ .Permalink }}">
+  <meta property="og:title" content="{{ .Site.Title }}">
+  <meta property="og:description"
+    content='{{if .Content}}{{ .Summary | truncate 150 }}{{else}}{{ .Site.Params.description }}{{end}}'>
+  <meta property="og:image" content="{{ .Site.BaseURL }}/meta.jpg">
+
+  <!-- Twitter -->
+  <meta property="twitter:card" content="summary_large_image">
+  <meta property="twitter:url" content="{{ .Permalink }}">
+  <meta property="twitter:title" content="{{ .Site.Title }}">
+  <meta property="twitter:description"
+    content='{{if .Content}}{{ .Summary | truncate 150 }}{{else}}{{ .Site.Params.description }}{{end}}'>
+  <meta property="twitter:image" content="{{ .Site.BaseURL }}/meta.jpg">
+
+  <link rel="canonical" href="{{ .Permalink }}" />
+</head>
+
+<body>
+
+  {{ partial "header.html" . }}
+
+  <main>
+    <div class="term container">
       <h1>{{ .Title }}</h1>
 
       {{ .Content }}
@@ -18,20 +56,23 @@
       {{ if isset .Params "synonyms" }}
         <h2>Synonyms</h2>
         <ul style="list-style: none;">
-        <li>{{ delimit .Params.synonyms ", " ", and " }}</li>
+          <li>{{ delimit .Params.synonyms ", " ", and " }}</li>
         </ul>
       {{ end }}
 
       {{ if isset .Params "abbreviation" }}
         <h2>Abbreviation</h2>
         <ul style="list-style: none;">
-        <li>{{ .Params.abbreviation }}</li>
+          <li>{{ .Params.abbreviation }}</li>
         </ul>
       {{ end }}
+    </div>
 
-    </main>
 
-    {{ partial "footer.html" . }}
+  </main>
 
-  </body>
+  {{ partial "footer.html" . }}
+
+</body>
+
 </html>

--- a/layouts/terms/single.html
+++ b/layouts/terms/single.html
@@ -22,14 +22,14 @@
   <title>{{ .Site.Title }}</title>
   <meta name="title" content="{{ .Site.Title }}">
   <meta name="description"
-    content='{{if .Content}}{{ .Summary | truncate 150 }}{{else}}{{ .Site.Params.description }}{{end}}'>
+    content='{{if .Summary}}{{ .Summary | truncate 150 }}{{else}}{{ .Site.Params.description }}{{end}}'>
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
   <meta property="og:url" content="{{ .Permalink }}">
   <meta property="og:title" content="{{ .Site.Title }}">
   <meta property="og:description"
-    content='{{if .Content}}{{ .Summary | truncate 150 }}{{else}}{{ .Site.Params.description }}{{end}}'>
+    content='{{if .Summary}}{{ .Summary | truncate 150 }}{{else}}{{ .Site.Params.description }}{{end}}'>
   <meta property="og:image" content="{{ .Site.BaseURL }}/meta.jpg">
 
   <!-- Twitter -->
@@ -37,7 +37,7 @@
   <meta property="twitter:url" content="{{ .Permalink }}">
   <meta property="twitter:title" content="{{ .Site.Title }}">
   <meta property="twitter:description"
-    content='{{if .Content}}{{ .Summary | truncate 150 }}{{else}}{{ .Site.Params.description }}{{end}}'>
+    content='{{if .Summary}}{{ .Summary | truncate 150 }}{{else}}{{ .Site.Params.description }}{{end}}'>
   <meta property="twitter:image" content="{{ .Site.BaseURL }}/meta.jpg">
 
   <link rel="canonical" href="{{ .Permalink }}" />


### PR DESCRIPTION
@ruf-io 

This PR fixes:
- #20 Create Meta Tags for Individual Terms
- #2 Style Term Page
- Added description in each terms markdown file.

<img width="1440" alt="Screenshot 2020-10-04 at 10 54 49 PM" src="https://user-images.githubusercontent.com/6929121/95022532-89fec100-0695-11eb-9356-7a5a45f76df7.png">

