### PR TITLE
Missing back link added

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,6 +1,10 @@
 <header>
   <div class="container pb-5 pt-1">
-    <h2 class="text-center">Developer Glossary</h2>
+    <a href="/">
+      <h2 class="text-center">
+        Developer Glossary
+      </h2>
+    </a>
   </div>
   <button class="toggle" onclick="toggle()">Toggle view mode</button>
 </header>


### PR DESCRIPTION
@ruf-io 

This PR fixes:
- After visiting the single term page, there was no way to go back, Hence attached link to title it self.