### PR TITLE
Hotfix alphabetize syntax

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -40,7 +40,7 @@
 
       {{ $letter := "A" }}
 
-      {{ range $index, $page := where .Site.RegularPages.Alphabetical "Section" "==" "terms" }}
+      {{ range $index, $page := where .Site.RegularPages.ByTitle "Section" "==" "terms" }}
 
         {{ if or (eq $index 0) (ne $letter (substr .Title 0 1)) }}
           {{ $letter := (substr .Title 0 1) }}


### PR DESCRIPTION
It looks like `Alphabetical` option was not available to the `.Site.RegularPages` object on the index template, I've switched to `ByTitle` which seems to do the same thing.