### PR TITLE
Enable `buildFuture` hugo config option

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,6 +6,8 @@ description = "test"
 
 disableKinds = ["taxonomy", "term"]
 
+buildFuture = true
+
 [params]
   titleEmoji = ":tada:"
 


### PR DESCRIPTION
Allows building of content with `date` set in the future.

***

Close #14 