### PR TITLE
Created responsive table of contents demo

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,11 +3,14 @@ languageCode = "en-us"
 title = "Developer Glossary"
 copyright = "MIT License, <a href='https://github.com/do-community/developer-glossary'>Contribute on GitHub</a>"
 
-disableKinds = ["taxonomy", "term"]
-
 [params]
   titleEmoji = ":tada:"
   description = "A developer's glossary built by the community, for the community."
 
 [Permalinks]
   term = ":slug"
+
+[taxonomies]
+  category = "categories"
+  tag = "tags"
+

--- a/content/terms/boilerplate.md
+++ b/content/terms/boilerplate.md
@@ -2,6 +2,7 @@
 title: "Boilerplate"
 date: 2020-10-03T21:20:27-04:00
 part-of-speech: noun
+tags: ["B"]
 ---
 
 A boilerplate is a collection of code snippets and assets that can be reused to boost development. 

--- a/content/terms/command-line-interface.md
+++ b/content/terms/command-line-interface.md
@@ -4,6 +4,7 @@ date: 2020-10-02T21:23:17-04:00
 part-of-speech: noun
 synonyms: ["Command Line"]
 abbreviation: CLI
+tags: ["C"]
 ---
 
 Refers to the text-input interface commonly used by developers to interact with computers and the services or processes running on them. A command-line interface accepts text input (commands) which execute processes and typically result in text output.

--- a/content/terms/comment.md
+++ b/content/terms/comment.md
@@ -2,6 +2,7 @@
 title: "Comment"
 date: 2020-10-3
 part-of-speech: noun, verb
+tags: ["C"]
 ---
 
 A comment is a portion of text that you put into the source code of a computer program to help explain what is happening in that piece of code. This text portion is ignored by the compiler/interpreter and is usually considered an understandaing aid to maintainers of the said computer program.

--- a/content/terms/favicon.md
+++ b/content/terms/favicon.md
@@ -2,6 +2,7 @@
 title: "Favicon"
 date: 2020-10-03T22:18:47+05:30
 part-of-speech: noun
+tags: ["F"]
 ---
 
 A favicon is a small 16x16 pixels icon used on web browsers to represent a website or a web page. Short for 'favorite icon', favicons are most commonly displayed on tabs at the top

--- a/content/terms/framework.md
+++ b/content/terms/framework.md
@@ -2,6 +2,7 @@
 title: "Framework"
 date: 2020-10-04T10:10:10-04:00
 part-of-speech: noun
+tags: ["F"]
 ---
 
 Suite of programs used in website or software development. 

--- a/content/terms/kluge.md
+++ b/content/terms/kluge.md
@@ -2,6 +2,7 @@
 title: "Kluge"
 date: 2020-10-02T21:23:17-04:00
 part-of-speech: noun
+tags: ["K"]
 ---
 
 A kluge is a term in the developer world for the kind of fix or solution to a problem that is rushed, "hacky" and not well thought out.

--- a/content/terms/linter.md
+++ b/content/terms/linter.md
@@ -2,6 +2,7 @@
 title: "Linter"
 date: 2020-10-32T10:06:00-08:00
 part-of-speech: noun, verb
+tags: ["L"]
 ---
 
 A linter is a tool for static code analysis that flags programming errors, bugs, and mistakes in a given style or programming language. The name originates from the extraneous fluff or lint shed from clothing.

--- a/content/terms/minimum-viable-product.md
+++ b/content/terms/minimum-viable-product.md
@@ -3,6 +3,7 @@ title: "Minimum Viable Product"
 date: 2020-10-03T21:20:37-04:00
 part-of-speech: noun
 abbreviation: MVP
+tags : ["M"]
 ---
 
 When working in web development, you may hear talk of “MVP” — or minimum viable product. 

--- a/content/terms/unicorn.md
+++ b/content/terms/unicorn.md
@@ -2,6 +2,7 @@
 title: "Unicorn"
 date: 2020-10-03T21:20:17-04:00
 part-of-speech: noun
+tags : ["U"]
 ---
 
 A Unicorn software developer is someone who knows web development and also has design skills.<br>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,68 +2,90 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z" crossorigin="anonymous">
-    <link rel="stylesheet" href="/main.css" type="text/css">
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js" integrity="sha384-B4gt1jrGC7Jh4AgTPSdUtOBvfO8shuf57BaghqFfPlYxofvL8/KUEfYiJOMMV+rV" crossorigin="anonymous"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="stylesheet"
+      href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
+      integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z"
+      crossorigin="anonymous"
+    />
+    <link rel="stylesheet" href="/main.css" type="text/css" />
+    <script
+      src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+      integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"
+      integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"
+      integrity="sha384-B4gt1jrGC7Jh4AgTPSdUtOBvfO8shuf57BaghqFfPlYxofvL8/KUEfYiJOMMV+rV"
+      crossorigin="anonymous"
+    ></script>
     <script src="/toggle.js"></script>
-  
+
     <!-- Primary Meta Tags -->
     <title>{{ .Site.Title }}</title>
-    <meta name="title" content="{{ .Site.Title }}">
-    <meta name="description" content="{{if .Site.Params.description}}{{ .Site.Params.description }}{{else}}{{.Description}}{{end}}">
-  
+    <meta name="title" content="{{ .Site.Title }}" />
+    <meta
+      name="description"
+      content="{{if .Site.Params.description}}{{ .Site.Params.description }}{{else}}{{.Description}}{{end}}"
+    />
+
     <!-- Open Graph / Facebook -->
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="{{ .Permalink }}">
-    <meta property="og:title" content="{{ .Site.Title }}">
-    <meta property="og:description" content="{{if .Site.Params.description}}{{ .Site.Params.description }}{{else}}{{.Description}}{{end}}">
-    <meta property="og:image" content="{{ .Site.BaseURL }}/meta.jpg">
-  
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="{{ .Permalink }}" />
+    <meta property="og:title" content="{{ .Site.Title }}" />
+    <meta
+      property="og:description"
+      content="{{if .Site.Params.description}}{{ .Site.Params.description }}{{else}}{{.Description}}{{end}}"
+    />
+    <meta property="og:image" content="{{ .Site.BaseURL }}/meta.jpg" />
+
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="{{ .Permalink }}">
-    <meta property="twitter:title" content="{{ .Site.Title }}">
-    <meta property="twitter:description" content="{{if .Site.Params.description}}{{ .Site.Params.description }}{{else}}{{.Description}}{{end}}">
-    <meta property="twitter:image" content="{{ .Site.BaseURL }}/meta.jpg">
-    
+    <meta property="twitter:card" content="summary_large_image" />
+    <meta property="twitter:url" content="{{ .Permalink }}" />
+    <meta property="twitter:title" content="{{ .Site.Title }}" />
+    <meta
+      property="twitter:description"
+      content="{{if .Site.Params.description}}{{ .Site.Params.description }}{{else}}{{.Description}}{{end}}"
+    />
+    <meta property="twitter:image" content="{{ .Site.BaseURL }}/meta.jpg" />
+
     <link rel="canonical" href="{{ .Permalink }}" />
   </head>
-  <body>
-    {{ partial "header.html" . }}
+  <body class="container-fluid">
     <main>
-
-      {{ .Content }}
-
-      {{ $letter := "A" }}
-
-      {{ range $index, $page := where .Site.RegularPages.ByTitle "Section" "==" "terms" }}
-
-        {{ if or (eq $index 0) (ne $letter (substr .Title 0 1)) }}
-          {{ $letter := (substr .Title 0 1) }}
-          <h2 class="text-center">{{ $letter }}</h2>
-          <hr>
-        {{ end }}
-        <div class="term container">
-          <h3>
-            <a href="{{.Permalink}}">
-              {{ .Title }}
-            </a>
-          </h3>
-
-          <div class=" definition container">
-            {{ .Content }}
-          </div>
+      {{ partial "header.html" . }}
+      <div class="row">
+         
+        <div class="col-sm-12 col-lg-2">
+          {{ partial "tags.html" . }}
         </div>
-      {{ end }}
-        
-      </main>
+        <div class="col-sm-12 col-lg-10">
+           
+            {{ .Content }} 
+            {{ $letter := "A" }} 
+            {{ range $index, $page := where .Site.RegularPages.ByTitle "Section" "==" "terms" }} 
+            {{ if or (eq $index 0) (ne $letter (substr .Title 01)) }} 
+            {{ $letter := (substr .Title 0 1) }}
+            <h2 class="text-center" id="{{ $letter }}">{{ $letter }}</h2>
+            <hr />
+            {{ end }}
+            <div class="term">
+              <h3>
+                <a id="{{ .Title }}" href="{{.Permalink}}"> {{ .Title }} </a>
+              </h3>
 
-      
-
+              <div class="definition">{{ .Content }}</div>
+            </div>
+            {{ end }}
+        </div>
+      </div>
       <h4>{{ partial "footer.html" . }}</h4>
-
+    </main>
   </body>
 </html>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,6 +1,7 @@
 <!-- <footer>MIT License - <a href="https://github.com/do-community/developer-glossary">Contribute on GitHub</a></footer> -->
 <!-- Footer -->
 <footer class="page-footer font-small unique-color-dark pt-4">
+  
 
     <!-- Footer Elements -->
     <div class="container">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,6 +1,9 @@
 <header>
-  <div class="container pb-5 pt-1">
-    <h2 class="text-center">Developer Glossary</h2>
+  <div class="row">
+    <div class="col-lg-2"></div>
+    <div class="col-lg-10">
+      <h2 class="text-center">Developer Glossary</h2>
+      <button class="toggle" id="toggler">Toggle view mode</button>
+    </div>
   </div>
-  <button class="toggle" id="toggler">Toggle view mode</button>
 </header>

--- a/layouts/partials/tags.html
+++ b/layouts/partials/tags.html
@@ -1,0 +1,29 @@
+<!-- {{range $name, $taxonomy := .Site.Taxonomies.tags}} 
+    {{ $cnt := .Count }}
+	{{ with $.Site.GetPage (printf "/tags/%s" $name) }}
+        <div class="tagbutton">
+		    <a href={{ .RelPermalink }} title="All pages with tag <i>{{$name}}</i>">{{ $name | upper}}</a>
+            <sup>{{$cnt}}</sup>
+            
+        </div>
+	{{end}}
+{{end}} -->
+
+<section class="toc">
+    <h2>Table of Contents</h2>
+    {{ range $taxonomyname, $taxonomy := .Site.Taxonomies }}
+        {{ if eq "tags" $taxonomyname }}
+        {{ range $key, $value := $taxonomy }}
+          
+            <a href="#{{ $key | upper}}">{{ $key | upper}}</a>
+          
+          <ul>
+          {{ range $value.Pages }}
+            <li><a href="#{{ .Title }}">{{ .Title }}</a></li>
+          {{ end }}
+          </ul>
+        {{ end }}
+      {{ end }}
+    {{ end }}
+</section>
+  

--- a/layouts/taxonomy/tag.html
+++ b/layouts/taxonomy/tag.html
@@ -1,0 +1,8 @@
+<ul>
+  {{ range .Data.Pages }}
+  <li>
+    <a href="{{.RelPermalink}}">{{ .Title }}</a>
+  </li>
+  {{ end }}
+</ul>
+

--- a/static/main.css
+++ b/static/main.css
@@ -53,3 +53,14 @@ hr {
     color: #ffffff;
     background-color: #072540;
 }
+
+
+@media only screen and (max-width: 1024px){
+  .toc > a {
+    display:inline;
+  }
+
+  .toc > ul {
+    display: none;
+  }
+}


### PR DESCRIPTION
This PR attempts to handle issue #15 .

However, because of the nature of design and etc there are potential issues that might arise from this.

What I have done was, introduced **taxonomies** in order for tagging to happen. So each entry in to the glossary will have a tag. For example, "Boilerplate" with the B tag. The table of contents is currently on the left hand side. But the issue here is that it is not in a fixed position. (So, if you scroll if there too much main contents, you might scroll down and over it) 

**Basically how it looks normally**

![image](https://user-images.githubusercontent.com/933858/95488731-9fe7eb00-09e1-11eb-888e-b7b385401ce2.png)

**How it looks on a mobile device** 

![image](https://user-images.githubusercontent.com/933858/95488907-d6256a80-09e1-11eb-8f3c-b3f7535db5d4.png)

On the mobile view, there are only the main alphabets.

There are many more improvements that can be potentially made, but I think this is it for now.

TLDR - A demo can be found [here](https://happy-albattani-772d75.netlify.app/) via a netlify demo deployment.
