### PR TITLE
fix typo in dev-ops page

### DIFF
--- a/content/terms/dev-ops.md
+++ b/content/terms/dev-ops.md
@@ -2,7 +2,7 @@
 title: "DevOps"
 date: 2020-10-16T2:30:45-04:00
 part-of-speech: noun
-synonyms: ["Devlopment Operations"]
+synonyms: ["Development Operations"]
 ---
 
 DevOps is the collaboration between operations and development teams within an organization to achieve shorter development cycles and greater product reliability.


### PR DESCRIPTION
Noticed that there was a typo in the spelling of 'Development' in the `dev-ops` page, so I decided that I will correct it.