### PR TITLE
Modified link colour on hover

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -140,3 +140,8 @@ strong {
 #page-header > .jumbotron {
   background-color: inherit;
 }
+
+
+a:hover{
+  color: #ff6ada;
+}


### PR DESCRIPTION
All links before used to turn blue on hovering. I modified the CSS file to have them turn just a slight bit darker than their original colour thus having it look better.


Before:

![image](https://user-images.githubusercontent.com/43912470/103231733-932ebf80-495e-11eb-98fe-150ffa232fb4.png)


After:

![image](https://user-images.githubusercontent.com/43912470/103231699-772b1e00-495e-11eb-90eb-7dbeaf26c11c.png)
